### PR TITLE
feat(backend): add model/jpa entities

### DIFF
--- a/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/Category.java
+++ b/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/Category.java
@@ -1,0 +1,39 @@
+package sg.nus.iss.spring.backend.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "category")
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private String name;
+
+    // Constructors
+    public Category() {
+    }
+
+    public Category(String name) {
+        this.name = name;
+    }
+
+    // Getters and Setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/DeliveryType.java
+++ b/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/DeliveryType.java
@@ -1,0 +1,60 @@
+package sg.nus.iss.spring.backend.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "delivery_type")
+public class DeliveryType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private String name;
+
+    private String description;
+
+    private float fee;
+
+    // Constructors
+    public DeliveryType() {}
+
+    public DeliveryType(String name, String description, float fee) {
+        this.name = name;
+        this.description = description;
+        this.fee = fee;
+    }
+
+    // Getters and Setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public float getFee() {
+        return fee;
+    }
+
+    public void setFee(float fee) {
+        this.fee = fee;
+    }
+}

--- a/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/Order.java
+++ b/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/Order.java
@@ -1,0 +1,126 @@
+package sg.nus.iss.spring.backend.model;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int orderId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "payment_type_id", nullable = false)
+    private PaymentType paymentType;
+
+    @ManyToOne
+    @JoinColumn(name = "delivery_type_id", nullable = false)
+    private DeliveryType deliveryType;
+
+    private float totalAmount;
+
+    private String status;
+
+    private LocalDateTime dateTime;
+
+    private String shippingAddress;
+
+    private float goodsServiceTax;
+
+    @ManyToMany
+    @JoinTable(
+            name = "order_items",
+            joinColumns = @JoinColumn(name = "order_id"),
+            inverseJoinColumns = @JoinColumn(name = "product_id"))
+    private List<Product> products;
+
+
+    // Getters and Setters
+    public int getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(int orderId) {
+        this.orderId = orderId;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public PaymentType getPaymentType() {
+        return paymentType;
+    }
+
+    public void setPaymentType(PaymentType paymentType) {
+        this.paymentType = paymentType;
+    }
+
+    public DeliveryType getDeliveryType() {
+        return deliveryType;
+    }
+
+    public void setDeliveryType(DeliveryType deliveryType) {
+        this.deliveryType = deliveryType;
+    }
+
+    public float getTotalAmount() {
+        return totalAmount;
+    }
+
+    public void setTotalAmount(float totalAmount) {
+        this.totalAmount = totalAmount;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getDateTime() {
+        return dateTime;
+    }
+
+    public void setDateTime(LocalDateTime dateTime) {
+        this.dateTime = dateTime;
+    }
+
+    public String getShippingAddress() {
+        return shippingAddress;
+    }
+
+    public void setShippingAddress(String shippingAddress) {
+        this.shippingAddress = shippingAddress;
+    }
+
+    public float getGoodsServiceTax() {
+        return goodsServiceTax;
+    }
+
+    public void setGoodsServiceTax(float goodsServiceTax) {
+        this.goodsServiceTax = goodsServiceTax;
+    }
+
+    public List<Product> getProducts() {
+        return products;
+    }
+
+    public void setProducts(List<Product> products) {
+        this.products = products;
+    }
+}

--- a/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/PaymentType.java
+++ b/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/PaymentType.java
@@ -1,0 +1,38 @@
+package sg.nus.iss.spring.backend.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "payment_type")
+public class PaymentType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private String name;
+
+    // Constructors
+    public PaymentType() {}
+
+    public PaymentType(String name) {
+        this.name = name;
+    }
+
+    // Getters and Setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/Product.java
+++ b/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/Product.java
@@ -1,0 +1,129 @@
+package sg.nus.iss.spring.backend.model;
+
+import jakarta.persistence.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "products")
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(length = 100)
+    private String brand;
+
+    @Column(nullable = false)
+    private float price;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column
+    private float rating;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    // Constructors
+    public Product() {
+    }
+
+    public Product(int id, String name, String description, String category, String brand,
+                   float price, int quantity, String imageUrl, float rating) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.brand = brand;
+        this.price = price;
+        this.quantity = quantity;
+        this.imageUrl = imageUrl;
+        this.rating = rating;
+    }
+
+    // Getters and Setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public void setBrand(String brand) {
+        this.brand = brand;
+    }
+
+    public float getPrice() {
+        return price;
+    }
+
+    public void setPrice(float price) {
+        this.price = price;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public float getRating() {
+        return rating;
+    }
+
+    public void setRating(float rating) {
+        this.rating = rating;
+    }
+}
+

--- a/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/User.java
+++ b/spring-backend/src/main/java/sg/nus/iss/spring/backend/model/User.java
@@ -1,0 +1,135 @@
+package sg.nus.iss.spring.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+
+import java.util.Date;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(name = "first_name", nullable = false, length = 50)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false, length = 50)
+    private String lastName;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false)
+    @JsonIgnore
+    private String password;
+
+    @Column(name = "phone_number", length = 20)
+    private String phoneNumber;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(length = 255)
+    private String address;
+
+    @Column(name = "date_of_birth")
+    @Temporal(TemporalType.DATE)
+    private Date dateOfBirth;
+
+    @Column(name = "user_role", nullable = false)
+    private String userRole;
+
+    // Constructors
+    public User() {
+    }
+
+    public User(String firstName, String lastName, String username, String password,
+                String phoneNumber, String email, String address, Date dateOfBirth, String userRole) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.username = username;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.email = email;
+        this.address = address;
+        this.dateOfBirth = dateOfBirth;
+        this.userRole = userRole;
+    }
+
+    // Getters and Setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public Date getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(Date dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getUserRole() {
+        return userRole;
+    }
+
+    public void setUserRole(String userRole) {
+        this.userRole = userRole;
+    }
+}
+


### PR DESCRIPTION
- Created JPA entities for the backend, representing core data models.
- Defined relationships between entities (e.g., one-to-many, many-to-one).
- Set up basic annotations for persistence (e.g., @Entity, @Id, @ManyToOne).
- Does not implement user cart entity